### PR TITLE
Use Web Worker in imagenet example

### DIFF
--- a/examples/imagenet.html
+++ b/examples/imagenet.html
@@ -43,22 +43,44 @@
   <p id="time">Exection time: </p>
 </body>
 <script src="./imagenet_class_index.js"></script>
-<script src="../dist/index.js"></script>
 <script>
-  let nnp = undefined;
-  const gpu = new GPU();
+  let startTime = 0;
   const image = new Image();
-  const resizeKernel = nnabla.ImageUtils.createAsyncResizeKernel([3, 224, 224], gpu, true);
+
+  // larger networks take longer processing time.
+  // let's offload the computation on Web Worker.
+  const worker = new Worker("./worker.js");
+
+  worker.addEventListener("message", (e) => {
+    if (e.data.type === "loadCompleted") {
+      document.getElementById("loadProgress").innerHTML = "Completed";
+    } else if (e.data.type === "executeCompleted") {
+      const endTime = performance.now();
+      document.getElementById("time").innerHTML = "Exection time: " + (endTime - startTime) + "ms";
+
+      // update preview
+      document.getElementById("preview").getContext("2d").putImageData(e.data.resizedImage, 0, 0);
+
+      // choose the best class
+      const output = e.data.data;
+      let maxIndex = 0;
+      let maxValue = output["y0"][0];
+      for (let i = 1; i < 1000; ++i) {
+        if (output["y0"][i] > maxValue) {
+          maxValue = output["y0"][i];
+          maxIndex = i;
+        }
+      }
+      document.getElementById("result").innerHTML = "Class: " + imagenetClasses[maxIndex];
+    }
+  });
 
   document.getElementById("nnpFile").addEventListener("change", function (evt) {
     document.getElementById("loadProgress").innerHTML = "Loading NNP...";
     const file = evt.target.files[0];
     const reader = new FileReader();
     reader.onload = function () {
-      nnabla.NNP.fromNNPData(this.result, gpu).then(function(_nnp) {
-        nnp = _nnp;
-        document.getElementById("loadProgress").innerHTML = "Completed";
-      });
+      worker.postMessage({type: "load", data: this.result});
     };
     reader.readAsBinaryString(file);
   }, false);
@@ -74,36 +96,11 @@
   }, false);
 
   image.onload = function(e) {
-    // Preprocess image
     const imageData = createImageData(e.target);
-    const array = nnabla.ImageUtils.convertImageToArray(imageData, 3, 1.0);
-    resizeKernel(array, imageData.height, imageData.width).then(resizedArray => {
-      // Update preview
-      const resizedData = nnabla.ImageUtils.convertArrayToImage(resizedArray.toArray(), 3, 224, 224, 1.0);
-      document.getElementById("preview").getContext("2d").putImageData(resizedData, 0, 0);
-
-      if (nnp === undefined) {
-        console.log("load NNP first.")
-        document.getElementById("result").innerHTML = "Load NNP first.";
-      } else {
-        const startTime = performance.now();
-        nnp.forwardAsync("runtime", {"x0": resizedArray}).then(function(output) {
-          const endTime = performance.now();
-
-          let maxIndex = 0;
-          let maxValue = output["y0"][0];
-          for (let i = 1; i < 1000; ++i) {
-            if (output["y0"][i] > maxValue) {
-              maxValue = output["y0"][i];
-              maxIndex = i;
-            }
-          }
-
-          document.getElementById("result").innerHTML = "Class: " + imagenetClasses[maxIndex];
-          document.getElementById("time").innerHTML = "Exection time: " + (endTime - startTime) + "ms";
-        });
-      }
-    });
+    document.getElementById("time").innerHTML = "Exection time: executing...";
+    document.getElementById("result").innerHTML = "Class: executing...";
+    startTime = performance.now();
+    worker.postMessage({type: "execute", data: imageData});
   }
 
   function createImageData(img) {

--- a/examples/worker.js
+++ b/examples/worker.js
@@ -1,0 +1,46 @@
+// Copyright 2022 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+importScripts("../dist/index.js");
+
+const gpu = new GPU();
+const resizeKernel = nnabla.ImageUtils.createAsyncResizeKernel([3, 224, 224], gpu, true);
+let nnp = null;
+
+function loadNNP(data) {
+  return nnabla.NNP.fromNNPData(data, gpu).then(function(_nnp) {
+    nnp = _nnp;
+  });
+}
+
+self.addEventListener("message", (e) => {
+  if (e.data.type === "load") {
+    loadNNP(e.data.data).then(() => {
+      self.postMessage({type: "loadCompleted"});
+    })
+  } else if (e.data.type === "execute") {
+    const image = e.data.data;
+    const array = nnabla.ImageUtils.convertImageToArray(image, 3, 1.0);
+    resizeKernel(array, image.height, image.width).then((resizedArray) => {
+      nnp.forwardAsync("runtime", {x0: resizedArray}).then((output) => {
+        const resizedData = nnabla.ImageUtils.convertArrayToImage(resizedArray.toArray(), 3, 224, 224, 1.0);
+        self.postMessage({
+          type: "executeCompleted",
+          data: output,
+          resizedImage: resizedData,
+        });
+      })
+    })
+  }
+});


### PR DESCRIPTION
This PR changes imagenet example to use Web Worker for parallel neural network execution. With this change, `nnabla-js` never prevents UI thread in the demo.