### PR TITLE
Remove npm installation instructions to mitigate potential supply chain risk

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ A JavaScript runtime for Neural Network Libraries.
 - Preprocess utilities (e.g. image resizing)
 
 ## installation
-```
-$ npm install nnabla-js
-```
+
+nnabla-js is **not available via NPM**.  
+Please clone this repository and build from source
 
 ## example
 Check out more [examples](examples)!


### PR DESCRIPTION
The README previously referenced `npm install nnabla-js`, but no official NPM package exists. This could allow malicious actors to hijack the package name. Removed all NPM installation references and clarified that nnabla-js should be installed from source.